### PR TITLE
Fix #393 The description of shows does not appear.

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -276,7 +276,7 @@ function radio_station_archive_list_shortcode( $post_type, $atts ) {
 		'description'  => 'excerpt',
 		'hide_empty'   => 0,
 		'time'         => $time_format,
-		'view'         => 0,
+		'view'         => 'none', // changed from 0 to none because of string comparison in PHP7
 		// --- taxonomy queries ---
 		'genre'        => '',
 		'language'     => '',


### PR DESCRIPTION
This fixes a problem with type comparison in PHP 7, bug report #393

In line 279 the variable `$atts['view']` is initialized with 0 as default.

In line 753 of `includes/shortcodes.php` there exists a type comparison:

` 'grid' == $atts['view']`

Because PHP 7 considers the integer 0 to be equal to a string, the show description was not shown in the shortcode. I fixed this by changing the default value from 0 to 'none'.

![imagen](https://user-images.githubusercontent.com/13654429/143505473-5d9128b8-73f6-49f4-b1fd-f84e9b506d86.png)
![imagen](https://user-images.githubusercontent.com/13654429/143505615-712ba615-e927-4683-bae8-48948160d7b4.png)

After the change:

![imagen](https://user-images.githubusercontent.com/13654429/143505691-5d331a79-d191-4d0b-9bbd-eaa908e2d43e.png)
![imagen](https://user-images.githubusercontent.com/13654429/143505707-8739fe83-5f08-4a8d-b75f-e2760e0267d3.png)
